### PR TITLE
Bring contrast to active and inactive tabs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const foregroundColor = '#eff0eb';
 const backgroundColor = '#282a36';
+const backgroundContrastColor = '#3b3d48';
 const red = '#ff5c57';
 const green = '#5af78e';
 const yellow = '#f3f99d';
@@ -51,6 +52,14 @@ exports.decorateConfig = config => Object.assign({}, config, {
 			opacity: 1;
 			transition: opacity 0.12s ease-in-out;
 			will-change: opacity;
+		}
+
+		.header_header {
+			background-color: ${backgroundContrastColor};
+		}
+
+		.tab_active {
+			background-color: ${backgroundColor};
 		}
 	`
 });

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 const foregroundColor = '#eff0eb';
 const backgroundColor = '#282a36';
-const backgroundContrastColor = '#3b3d48';
 const red = '#ff5c57';
 const green = '#5af78e';
 const yellow = '#f3f99d';
@@ -54,12 +53,20 @@ exports.decorateConfig = config => Object.assign({}, config, {
 			will-change: opacity;
 		}
 
-		.header_header {
-			background-color: ${backgroundContrastColor};
+		.tab_tab::before {
+			content: '';
+			position: absolute;
+			bottom: 0;
+			left: 0;
+			right: 0;
+			height: 1px;
+			background-color: rgba(255, 106, 193, 0.4);
+			transform: scaleX(0);
 		}
 
-		.tab_active {
-			background-color: ${backgroundColor};
+		.tab_tab.tab_active::before {
+			transform: scaleX(1);
+			transition: all 200ms cubic-bezier(0.0, 0.0, 0.2, 1);
 		}
 	`
 });


### PR DESCRIPTION
I find it hard to see which tab is active and differentiate tabs in general. These things are only viewable by looking at the border. 

I added a background contrast color for the header/tabs section. Merge if you like. 

Example
![hyper-snazzy-tabs](https://cloud.githubusercontent.com/assets/657797/23856086/80f921a8-07f8-11e7-905b-1b5be1d79c23.gif)

For others: If not merged just copy the added CSS to your custom CSS in `.hyper.js`.