### PR TITLE
Allow overriding of backgroundColor property

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const magenta = '#ff6ac1';
 const cyan = '#9aedfe';
 
 exports.decorateConfig = config => Object.assign({}, config, {
-	backgroundColor,
+	backgroundColor: config.backgroundColor || backgroundColor,,
 	foregroundColor,
 	borderColor: '#222430',
 	cursorColor: '#97979b',

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const magenta = '#ff6ac1';
 const cyan = '#9aedfe';
 
 exports.decorateConfig = config => Object.assign({}, config, {
-	backgroundColor: config.backgroundColor || backgroundColor,,
+	backgroundColor: config.backgroundColor || backgroundColor,
 	foregroundColor,
 	borderColor: '#222430',
 	cursorColor: '#97979b',


### PR DESCRIPTION
Allows overriding of the `backgroundColor` property for slight user customisability. Feel free to close if you feel it's not necessary for the production version of the theme.