### PR TITLE
Remove background-color declaration from active tab

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,6 @@ exports.decorateConfig = config => Object.assign({}, config, {
 			left: 0;
 			right: 0;
 			height: 1px;
-			background-color: rgba(255, 106, 193, 0.4);
 			transform: scaleX(0);
 		}
 


### PR DESCRIPTION
Removes pink bottom border on active tabs in Hyper `~1.4.0`.

Fixes #23.