### PR TITLE
Only lower the opacity on inactive panes

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ exports.decorateConfig = config => Object.assign({}, config, {
 			border-color: rgba(255, 106, 193, 0.25);
 		}
 
-		.term_fit:not(.term_term) {
+		.term_fit:not(.term_active) {
 			opacity: 0.6;
 		}
 


### PR DESCRIPTION
This fixes an issue where the opacity was lowered for all panes in v2.0 of Hyper.

Fixes #27.