### PR TITLE
Only lower the opacity of inactive panes in Hyper 2.0.2

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,11 +43,11 @@ exports.decorateConfig = config => Object.assign({}, config, {
 			border-color: rgba(255, 106, 193, 0.25);
 		}
 
-		.term_fit:not(.term_active) {
+		.terminal {
 			opacity: 0.6;
 		}
 
-		.term_fit.term_active {
+		.terminal.focus {
 			opacity: 1;
 			transition: opacity 0.12s ease-in-out;
 			will-change: opacity;


### PR DESCRIPTION
I save the same problem as in #27 after upgrading to pre-release 2.0.2.

It seems term_active is always there in 2.0.2. Don't know if that is a bug in Hyper 2.0.2 or if it's intentional, but looking at what changes when inactivating a terminal, I got it working with this fix.

Very new to Hyper so I don't know if it's a good fix.