### PR TITLE
fix: Inactive pane opacity in Hyper 1.4.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,11 +43,13 @@ exports.decorateConfig = config => Object.assign({}, config, {
 			border-color: rgba(255, 106, 193, 0.25);
 		}
 
-		.terminal {
+		.terminal,
+		.term_fit:not(.term_term) {
 			opacity: 0.6;
 		}
 
-		.terminal.focus {
+		.terminal.focus,
+		.term_fit.term_active {
 			opacity: 1;
 			transition: opacity 0.12s ease-in-out;
 			will-change: opacity;


### PR DESCRIPTION
The changes in #29 have broken the inactive pane opacity in `1.4.x`. This PR reintroduces the selectors for the current stable release of Hyper.