### PR TITLE
Various fixes for the Hyper 2 stable release

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ exports.decorateConfig = config => Object.assign({}, config, {
 	borderColor: '#222430',
 	cursorColor: '#97979b',
 	cursorAccentColor: backgroundColor,
-	selectionColor: 'rgba(151,151,155,0.3)',
+	selectionColor: 'rgba(151, 151, 155, 0.2)',
 	colors: {
 		black: backgroundColor,
 		red,
@@ -53,7 +53,7 @@ exports.decorateConfig = config => Object.assign({}, config, {
 		}
 		.tab_tab.tab_active::before {
 			transform: scaleX(1);
-			transition: all 200ms cubic-bezier(0.0, 0.0, 0.2, 1);
+			transition: all 200ms cubic-bezier(0, 0, 0.2, 1);
 		}
 
 		/* Fade the title of inactive tabs and the content of inactive panes */

--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@ exports.decorateConfig = config => Object.assign({}, config, {
 	foregroundColor,
 	borderColor: '#222430',
 	cursorColor: '#97979b',
+	cursorAccentColor: backgroundColor,
+	selectionColor: 'rgba(151,151,155,0.3)',
 	colors: {
 		black: backgroundColor,
 		red,
@@ -32,29 +34,12 @@ exports.decorateConfig = config => Object.assign({}, config, {
 		lightWhite: foregroundColor
 	},
 	css: `
-		${config.css}
-
 		/* Hide title when only one tab */
 		.tabs_title {
 			display: none !important;
 		}
 
-		.tab_active:before {
-			border-color: rgba(255, 106, 193, 0.25);
-		}
-
-		.terminal,
-		.term_fit:not(.term_term) {
-			opacity: 0.6;
-		}
-
-		.terminal.focus,
-		.term_fit.term_active {
-			opacity: 1;
-			transition: opacity 0.12s ease-in-out;
-			will-change: opacity;
-		}
-
+		/* Add a highlight line below the active tab */
 		.tab_tab::before {
 			content: '';
 			position: absolute;
@@ -64,19 +49,26 @@ exports.decorateConfig = config => Object.assign({}, config, {
 			height: 1px;
 			background-color: rgba(255, 106, 193, 0.4);
 			transform: scaleX(0);
+			will-change: transform;
 		}
-
-		.tab_first {
-			border-left-color: transparent !important;
-		}
-
-		.tab_tab:not(.tab_active) {
-			color: #666;
-		}
-
 		.tab_tab.tab_active::before {
 			transform: scaleX(1);
 			transition: all 200ms cubic-bezier(0.0, 0.0, 0.2, 1);
 		}
+
+		/* Fade the title of inactive tabs and the content of inactive panes */
+		.tab_text,
+		.term_term {
+			opacity: 0.6;
+			will-change: opacity;
+		}
+		.tab_active .tab_text,
+		.term_active .term_term {
+			opacity: 1;
+			transition: opacity 0.12s ease-in-out;
+		}
+
+		/* Allow custom css / overrides */
+		${config.css}
 	`
 });


### PR DESCRIPTION
Fixes and tidies up these things for the Hyper 2 stable release:
- Changes the bright pink selection color to grey.
- Allow people to override the styles without needing to use `!important`.
- Organise the styles and add comments.
- Removed styles that aren't needed for Hyper 2 (since it's been released to stable).
- Fixes the inactive tab/pane fading out feature.

Fixes #41
Fixes #42
Fixes #33

Let me know if you want me to make any changes. 

Also I'm open to helping maintain hyper-snazzy if you're looking for maintainers (since I use it daily). 😀